### PR TITLE
Resolution when packer absent from syspath

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,4 +40,4 @@
     remote_src: yes
     src: "{{ packer_download_dir }}/{{ packer_zip_url|basename }}"
     dest: /usr/local/bin
-  when: "packer_version_result.stdout != 'Packer v'+packer_version"
+  when: "packer_version_result.stdout|default('') != 'Packer v'+packer_version"


### PR DESCRIPTION
When you are running the command check for packer version, this will obviously
fail when packer hasnt been installed into syspath yet. There is an
ignore_errors to handle this but the next extract task relies on register
variable and attr stdout which doesn't exist. Hence that will fail on ansible
2.2+.